### PR TITLE
Fix parentNumber in API calls

### DIFF
--- a/app/dashboard/sendToTeacher/page.jsx
+++ b/app/dashboard/sendToTeacher/page.jsx
@@ -55,7 +55,7 @@ export default function SendToTeasher() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        parentNumber: "201095427168", // Replace with parentPhone
+        parentNumber: selectedTeacher.phone,
         message: message,
       }),
     })

--- a/app/dashboard/sentRequests/page.jsx
+++ b/app/dashboard/sentRequests/page.jsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 export default function SendRequests() {
   const [forms, setForms] = useState([]);
   const [students, setStudents] = useState([]);
+  const [parentPhone, setParentPhone] = useState(null);
 
   useEffect(() => {
     fetch("/api/forms") // replace with your API endpoint
@@ -34,8 +35,17 @@ export default function SendRequests() {
     return student ? student.class : "Student not found";
   };
 
+  const getStudentParentNumber = (studentId) => {
+    const student = students.find((student) => student.number === studentId);
+    return student ? student.parentNumber : "Student not found";
+  };
+  
+
   const handleApproval = (formId) => {
     // Make an API call to update the form data
+    const form = forms.find((form) => form.id === formId);
+    const student = students.find((student) => student.number === form.studentId);
+    const parentNumber = student.parentNumber;
     fetch(`/api/forms/${formId}`, {
       method: "PUT",
       headers: {
@@ -52,7 +62,7 @@ export default function SendRequests() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        parentNumber: "201095427168", // Replace with parentPhone
+        parentNumber: parentNumber, // Replace with parentPhone
         message: "تم قبول طلب الاستئذان",
       }),
     })

--- a/app/parentPre/[id]/page.jsx
+++ b/app/parentPre/[id]/page.jsx
@@ -48,7 +48,7 @@ export default function ParentPre() {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            parentNumber: "201095427168", // Replace with parentPhone
+            parentNumber: parentPhone,
             code: verificationCode,
           }),
         })


### PR DESCRIPTION
This pull request fixes the issue with the parentNumber parameter in the API calls. Previously, the parentNumber was hardcoded as "201095427168" in multiple API calls. This PR replaces the hardcoded value with the actual parentNumber obtained from the selectedTeacher or student data.

Fixes #1234